### PR TITLE
Updating the issues table to use the GitHub V3 API

### DIFF
--- a/github/github.issues.open.xml
+++ b/github/github.issues.open.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
   <meta>
-    <author>Dav Glass</author>
+    <author>Pradeep B V</author>
     <documentationURL></documentationURL>
-    <sampleQuery>select * from {table} where id='spullara' and repo='yql-tables'</sampleQuery>
+    <sampleQuery>select * from {table} where id='yahoo' and repo='mojito'</sampleQuery>
   </meta>
   <bindings>
     <select itemPath="issues.issue" produces="XML">
       <urls>
-        <url>http://github.com/api/v2/xml/issues/list/{id}/{repo}/open</url>
+		<url>https://api.github.com/repos/{id}/{repo}/issues?state=open</url>
       </urls>
       <inputs>
         <key id="id" type="xs:string" paramType="path" required="true"/>


### PR DESCRIPTION
GitHub have changed their API structure with their new version V3.
Hence the API call had to be changed to reface the same documented in:
http://developer.github.com/v3/issues/
